### PR TITLE
Debug API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,4 @@ edition = "2018"
 [features]
 default = [ "std" ]
 std = []
+debug = []

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,0 +1,10 @@
+/// The native debug interface exposed to the ewasm contract. These functions are for testing
+/// purposes only. On a live VM, any bytecode trying to import these symbols will be rejected.
+extern "C" {
+    pub fn debug_print32(value: u32);
+    pub fn debug_print64(value: u64);
+    pub fn debug_printMem(offset: *const u32, len: u32);
+    pub fn debug_printMemHex(offset: *const u32, len: u32);
+    pub fn debug_printStorage(pathOffset: *const u32);
+    pub fn debug_printStorageHex(pathOffset: *const u32);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,9 @@
 mod native;
 pub mod types;
 
+#[cfg(feature = "debug")]
+pub mod debug;
+
 #[cfg(not(feature = "std"))]
 pub mod convert;
 


### PR DESCRIPTION
Adds debug methods specified in [ECI](https://github.com/ewasm/design/blob/master/contract_interface.md#debug-mode).

These methods would have to be remapped by chisel, but the remapping part is being refactored in https://github.com/wasmx/wasm-chisel/pull/66, so I'll wait for that to be merged and then work on a PR.