### PR TITLE
Introduce qimalloc as an allocator option

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ description = "ewasm API for Rust"
 edition = "2018"
 
 [dependencies]
-wee_alloc = "0.4.4"
+cfg-if = "0.1.7"
+wee_alloc = { version = "0.4.4", optional = true }
+qimalloc = { version = "0.1", optional = true }
 
 [features]
-default = [ "std" ]
+default = ["std", "wee_alloc"]
 std = []
 debug = []
 experimental = []

--- a/circle.yml
+++ b/circle.yml
@@ -34,3 +34,5 @@ jobs:
              cargo build --release --no-default-features --features experimental
              cargo build --release --features experimental,debug
              cargo build --release --no-default-features --features experimental,debug
+             cargo build --release --features wee_alloc
+             cargo build --release --features qimalloc

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,10 +19,21 @@
 ///     finish_data(&a.bytes);
 /// }
 /// ```
-extern crate wee_alloc;
 
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+#[macro_use]
+extern crate cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "wee_alloc")] {
+        extern crate wee_alloc;
+        #[global_allocator]
+        static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+    } else if #[cfg(feature = "qimalloc")] {
+        extern crate qimalloc;
+        #[global_allocator]
+        static ALLOC: qimalloc::QIMalloc = qimalloc::QIMalloc::INIT;
+    }
+}
 
 mod native;
 pub mod types;


### PR DESCRIPTION
Closes #46.

So far it's a really dumb allocator. It simply tries to allocate enough wasm pages everytime the `alloc` method is called (i.e. pages are not filled with subsequent alloc calls). It also doesn't dealloc. I tested it with `runevm+hera` and it passes some tests.