### PR TITLE
Use wasm_import_module and remove function name prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "ewasm_api"
+name = "ss_ewasm_api"
 version = "0.11.0"
-authors = ["Alex Beregszaszi <alex@rtfs.hu>", "Jake Lang <jak3lang@gmail.com>"]
+authors = ["Alex Beregszaszi <alex@rtfs.hu>", "Jake Lang <jak3lang@gmail.com>", "Antonio Yang <yanganto@gmail.com>"]
 license = "Apache-2.0"
-repository = "https://github.com/ewasm/ewasm-rust-api"
+repository = "https://github.com/second-state/ewasm-rust-api"
 description = "ewasm API for Rust"
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
-# ewasm-rust-api
+# ss-ewasm-rust-api
+
+A fork from ewasm/ewasm-rust-api
+
+### Why we fork on this?
+
+We open a [PR](https://github.com/ewasm/ewasm-rust-api/pull/80) to upstream to use the `wasm_import_module` and remove the function prefix,
+and it still pending not merge.
+This modification will affect on using WasmEdge in [SewUp](https://github.com/second-state/SewUp), and block the release of SewUp.
+So we fork and release it into crate.io.
+
 
 ![Build](https://circleci.com/gh/ewasm/ewasm-rust-api.svg?style=shield&circle-token=:circle-token)
 ![Version](https://img.shields.io/crates/v/ewasm-api.svg)

--- a/src/bignum.rs
+++ b/src/bignum.rs
@@ -4,9 +4,10 @@ use crate::types::Uint256;
 /// The low-level interface to the system library. Use the wrapper functions unless you know what
 /// you're doing.
 pub mod native {
+    #[link(wasm_import_module = "bignum")]
     extern "C" {
-        pub fn bignum_mul256(a: *const u32, b: *const u32, ret: *const u32);
-        pub fn bignum_umulmod256(a: *const u32, b: *const u32, modulo: *const u32, ret: *const u32);
+        pub fn mul256(a: *const u32, b: *const u32, ret: *const u32);
+        pub fn umulmod256(a: *const u32, b: *const u32, modulo: *const u32, ret: *const u32);
     }
 }
 
@@ -15,7 +16,7 @@ pub fn mul256(a: &Uint256, b: &Uint256) -> Uint256 {
     let mut ret = Uint256::default();
 
     unsafe {
-        native::bignum_mul256(
+        native::mul256(
             a.bytes.as_ptr() as *const u32,
             b.bytes.as_ptr() as *const u32,
             ret.bytes.as_mut_ptr() as *const u32,
@@ -30,7 +31,7 @@ pub fn umulmod256(a: &Uint256, b: &Uint256, modulo: &Uint256) -> Uint256 {
     let mut ret = Uint256::default();
 
     unsafe {
-        native::bignum_umulmod256(
+        native::umulmod256(
             a.bytes.as_ptr() as *const u32,
             b.bytes.as_ptr() as *const u32,
             modulo.bytes.as_ptr() as *const u32,

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -5,47 +5,48 @@ use crate::types::StorageKey;
 
 /// The native interface for debugging functions.
 mod native {
+    #[link(wasm_import_module = "debug")]
     extern "C" {
-        pub fn debug_print32(value: u32);
-        pub fn debug_print64(value: u64);
-        pub fn debug_printMem(offset: *const u32, len: u32);
-        pub fn debug_printMemHex(offset: *const u32, len: u32);
-        pub fn debug_printStorage(pathOffset: *const u32);
-        pub fn debug_printStorageHex(pathOffset: *const u32);
+        pub fn print32(value: u32);
+        pub fn print64(value: u64);
+        pub fn printMem(offset: *const u32, len: u32);
+        pub fn printMemHex(offset: *const u32, len: u32);
+        pub fn printStorage(pathOffset: *const u32);
+        pub fn printStorageHex(pathOffset: *const u32);
     }
 }
 
 /// Prints a string.
 pub fn log(msg: &str) {
-    unsafe { native::debug_printMem(msg.as_ptr() as *const u32, msg.len() as u32) }
+    unsafe { native::printMem(msg.as_ptr() as *const u32, msg.len() as u32) }
 }
 
 /// Prints an unsigned 32-bit int.
 pub fn print32(value: u32) {
-    unsafe { native::debug_print32(value) }
+    unsafe { native::print32(value) }
 }
 
 /// Prints an unsigned 64-bit int.
 pub fn print64(value: u64) {
-    unsafe { native::debug_print64(value) }
+    unsafe { native::print64(value) }
 }
 
 /// Prints the contents of a slice.
 pub fn print_mem(slice: &[u8]) {
-    unsafe { native::debug_printMem(slice.as_ptr() as *const u32, slice.len() as u32) }
+    unsafe { native::printMem(slice.as_ptr() as *const u32, slice.len() as u32) }
 }
 
 /// Prints the contents of a slice in hexadecimal format.
 pub fn print_mem_hex(slice: &[u8]) {
-    unsafe { native::debug_printMemHex(slice.as_ptr() as *const u32, slice.len() as u32) }
+    unsafe { native::printMemHex(slice.as_ptr() as *const u32, slice.len() as u32) }
 }
 
 /// Prints the value of a storage key.
 pub fn print_storage(key: &StorageKey) {
-    unsafe { native::debug_printStorage(key.bytes.as_ptr() as *const u32) }
+    unsafe { native::printStorage(key.bytes.as_ptr() as *const u32) }
 }
 
 /// Prints the value of a storage key in hexadecimal format.
 pub fn print_storage_hex(key: &StorageKey) {
-    unsafe { native::debug_printStorageHex(key.bytes.as_ptr() as *const u32) }
+    unsafe { native::printStorageHex(key.bytes.as_ptr() as *const u32) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,13 +137,13 @@ pub enum CreateResult {
 /// contract at deployment time, and hence is unneeded in most cases.
 pub fn consume_gas(amount: u64) {
     unsafe {
-        native::ethereum_useGas(amount);
+        native::useGas(amount);
     }
 }
 
 /// Returns the gas left in the current call.
 pub fn gas_left() -> u64 {
-    unsafe { native::ethereum_getGasLeft() }
+    unsafe { native::getGasLeft() }
 }
 
 /// Returns the executing address.
@@ -151,7 +151,7 @@ pub fn current_address() -> Address {
     let mut ret = Address::default();
 
     unsafe {
-        native::ethereum_getAddress(ret.bytes.as_mut_ptr() as *const u32);
+        native::getAddress(ret.bytes.as_mut_ptr() as *const u32);
     }
 
     ret
@@ -162,7 +162,7 @@ pub fn external_balance(address: &Address) -> EtherValue {
     let mut ret = EtherValue::default();
 
     unsafe {
-        native::ethereum_getExternalBalance(
+        native::getExternalBalance(
             address.bytes.as_ptr() as *const u32,
             ret.bytes.as_mut_ptr() as *const u32,
         );
@@ -176,7 +176,7 @@ pub fn block_coinbase() -> Address {
     let mut ret = Address::default();
 
     unsafe {
-        native::ethereum_getBlockCoinbase(ret.bytes.as_mut_ptr() as *const u32);
+        native::getBlockCoinbase(ret.bytes.as_mut_ptr() as *const u32);
     }
 
     ret
@@ -187,7 +187,7 @@ pub fn block_difficulty() -> Difficulty {
     let mut ret = Difficulty::default();
 
     unsafe {
-        native::ethereum_getBlockDifficulty(ret.bytes.as_mut_ptr() as *const u32);
+        native::getBlockDifficulty(ret.bytes.as_mut_ptr() as *const u32);
     }
 
     ret
@@ -195,7 +195,7 @@ pub fn block_difficulty() -> Difficulty {
 
 /// Returns the gas limit of the most recent block.
 pub fn block_gas_limit() -> u64 {
-    unsafe { native::ethereum_getBlockGasLimit() }
+    unsafe { native::getBlockGasLimit() }
 }
 
 /// Returns the hash of the `number`th most recent block.
@@ -203,7 +203,7 @@ pub fn block_hash(number: u64) -> Hash {
     let mut ret = Hash::default();
 
     unsafe {
-        native::ethereum_getBlockHash(number, ret.bytes.as_mut_ptr() as *const u32);
+        native::getBlockHash(number, ret.bytes.as_mut_ptr() as *const u32);
     }
 
     ret
@@ -211,12 +211,12 @@ pub fn block_hash(number: u64) -> Hash {
 
 /// Returns the number of the most recent block.
 pub fn block_number() -> u64 {
-    unsafe { native::ethereum_getBlockNumber() }
+    unsafe { native::getBlockNumber() }
 }
 
 /// Returns the timestamp of the most recent block.
 pub fn block_timestamp() -> u64 {
-    unsafe { native::ethereum_getBlockTimestamp() }
+    unsafe { native::getBlockTimestamp() }
 }
 
 /// Returns the gas price of the currently executing call.
@@ -224,7 +224,7 @@ pub fn tx_gas_price() -> EtherValue {
     let mut ret = EtherValue::default();
 
     unsafe {
-        native::ethereum_getTxGasPrice(ret.bytes.as_mut_ptr() as *const u32);
+        native::getTxGasPrice(ret.bytes.as_mut_ptr() as *const u32);
     }
 
     ret
@@ -235,7 +235,7 @@ pub fn tx_origin() -> Address {
     let mut ret = Address::default();
 
     unsafe {
-        native::ethereum_getTxOrigin(ret.bytes.as_mut_ptr() as *const u32);
+        native::getTxOrigin(ret.bytes.as_mut_ptr() as *const u32);
     }
 
     ret
@@ -251,7 +251,7 @@ fn log(
     topic4: *const u8,
 ) {
     unsafe {
-        native::ethereum_log(
+        native::log(
             data.as_ptr() as *const u32,
             data.len() as u32,
             topic_count as u32,
@@ -268,10 +268,10 @@ pub fn log0(data: &[u8]) {
     log(
         data,
         0,
-        0 as *const u8,
-        0 as *const u8,
-        0 as *const u8,
-        0 as *const u8,
+        core::ptr::null::<u8>(),
+        core::ptr::null::<u8>(),
+        core::ptr::null::<u8>(),
+        core::ptr::null::<u8>(),
     )
 }
 
@@ -281,9 +281,9 @@ pub fn log1(data: &[u8], topic1: &LogTopic) {
         data,
         1,
         topic1.bytes.as_ptr() as *const u8,
-        0 as *const u8,
-        0 as *const u8,
-        0 as *const u8,
+        core::ptr::null::<u8>(),
+        core::ptr::null::<u8>(),
+        core::ptr::null::<u8>(),
     )
 }
 
@@ -294,8 +294,8 @@ pub fn log2(data: &[u8], topic1: &LogTopic, topic2: &LogTopic) {
         2,
         topic1.bytes.as_ptr() as *const u8,
         topic2.bytes.as_ptr() as *const u8,
-        0 as *const u8,
-        0 as *const u8,
+        core::ptr::null::<u8>(),
+        core::ptr::null::<u8>(),
     )
 }
 
@@ -307,7 +307,7 @@ pub fn log3(data: &[u8], topic1: &LogTopic, topic2: &LogTopic, topic3: &LogTopic
         topic1.bytes.as_ptr() as *const u8,
         topic2.bytes.as_ptr() as *const u8,
         topic3.bytes.as_ptr() as *const u8,
-        0 as *const u8,
+        core::ptr::null::<u8>(),
     )
 }
 
@@ -338,7 +338,7 @@ pub fn call_mutable(
     data: &[u8],
 ) -> CallResult {
     let ret = unsafe {
-        native::ethereum_call(
+        native::call(
             gas_limit,
             address.bytes.as_ptr() as *const u32,
             value.bytes.as_ptr() as *const u32,
@@ -358,7 +358,7 @@ pub fn call_mutable(
 /// Executes another account's code in the context of the caller.
 pub fn call_code(gas_limit: u64, address: &Address, value: &EtherValue, data: &[u8]) -> CallResult {
     let ret = unsafe {
-        native::ethereum_callCode(
+        native::callCode(
             gas_limit,
             address.bytes.as_ptr() as *const u32,
             value.bytes.as_ptr() as *const u32,
@@ -379,7 +379,7 @@ pub fn call_code(gas_limit: u64, address: &Address, value: &EtherValue, data: &[
 /// and value.
 pub fn call_delegate(gas_limit: u64, address: &Address, data: &[u8]) -> CallResult {
     let ret = unsafe {
-        native::ethereum_callDelegate(
+        native::callDelegate(
             gas_limit,
             address.bytes.as_ptr() as *const u32,
             data.as_ptr() as *const u32,
@@ -398,7 +398,7 @@ pub fn call_delegate(gas_limit: u64, address: &Address, data: &[u8]) -> CallResu
 /// Executes a static call which cannot mutate the state.
 pub fn call_static(gas_limit: u64, address: &Address, data: &[u8]) -> CallResult {
     let ret = unsafe {
-        native::ethereum_callStatic(
+        native::callStatic(
             gas_limit,
             address.bytes.as_ptr() as *const u32,
             data.as_ptr() as *const u32,
@@ -419,7 +419,7 @@ pub fn create(value: &EtherValue, data: &[u8]) -> CreateResult {
     let mut address = Address::default();
 
     let ret = unsafe {
-        native::ethereum_create(
+        native::create(
             value.bytes.as_ptr() as *const u32,
             data.as_ptr() as *const u32,
             data.len() as u32,
@@ -438,7 +438,7 @@ pub fn create(value: &EtherValue, data: &[u8]) -> CreateResult {
 /// Executes callDataCopy, but does not check for overflow.
 pub fn unsafe_calldata_copy(from: usize, length: usize, ret: &mut [u8]) {
     unsafe {
-        native::ethereum_callDataCopy(ret.as_mut_ptr() as *const u32, from as u32, length as u32);
+        native::callDataCopy(ret.as_mut_ptr() as *const u32, from as u32, length as u32);
     }
 }
 
@@ -466,7 +466,7 @@ pub fn calldata_copy(from: usize, length: usize, ret: &mut [u8]) -> Result<(), E
 
 /// Returns the length of the call data supplied with the currently executing call.
 pub fn calldata_size() -> usize {
-    unsafe { native::ethereum_getCallDataSize() as usize }
+    unsafe { native::getCallDataSize() as usize }
 }
 
 /// Returns the sender of the currently executing call.
@@ -474,7 +474,7 @@ pub fn caller() -> Address {
     let mut ret = Address::default();
 
     unsafe {
-        native::ethereum_getCaller(ret.bytes.as_mut_ptr() as *const u32);
+        native::getCaller(ret.bytes.as_mut_ptr() as *const u32);
     }
 
     ret
@@ -485,7 +485,7 @@ pub fn callvalue() -> EtherValue {
     let mut ret = EtherValue::default();
 
     unsafe {
-        native::ethereum_getCallValue(ret.bytes.as_mut_ptr() as *const u32);
+        native::getCallValue(ret.bytes.as_mut_ptr() as *const u32);
     }
 
     ret
@@ -494,7 +494,7 @@ pub fn callvalue() -> EtherValue {
 /// Executes codeCopy, but does not check for overflow.
 pub fn unsafe_code_copy(from: usize, length: usize, ret: &mut [u8]) {
     unsafe {
-        native::ethereum_codeCopy(ret.as_mut_ptr() as *const u32, from as u32, length as u32);
+        native::codeCopy(ret.as_mut_ptr() as *const u32, from as u32, length as u32);
     }
 }
 
@@ -522,13 +522,13 @@ pub fn code_copy(from: usize, length: usize, ret: &mut [u8]) -> Result<(), Error
 
 /// Returns the size of the currently executing code.
 pub fn code_size() -> usize {
-    unsafe { native::ethereum_getCodeSize() as usize }
+    unsafe { native::getCodeSize() as usize }
 }
 
 /// Executes externalCodeCopy, but does not check for overflow.
 pub fn unsafe_external_code_copy(address: &Address, from: usize, length: usize, ret: &mut [u8]) {
     unsafe {
-        native::ethereum_externalCodeCopy(
+        native::externalCodeCopy(
             address.bytes.as_ptr() as *const u32,
             ret.as_mut_ptr() as *const u32,
             from as u32,
@@ -566,13 +566,13 @@ pub fn external_code_copy(
 
 /// Returns the size of the code at the specified address.
 pub fn external_code_size(address: &Address) -> usize {
-    unsafe { native::ethereum_getExternalCodeSize(address.bytes.as_ptr() as *const u32) as usize }
+    unsafe { native::getExternalCodeSize(address.bytes.as_ptr() as *const u32) as usize }
 }
 
 /// Executes returnDataCopy, but does not check for overflow.
 pub fn unsafe_returndata_copy(from: usize, length: usize, ret: &mut [u8]) {
     unsafe {
-        native::ethereum_returnDataCopy(ret.as_mut_ptr() as *const u32, from as u32, length as u32);
+        native::returnDataCopy(ret.as_mut_ptr() as *const u32, from as u32, length as u32);
     }
 }
 
@@ -600,7 +600,7 @@ pub fn returndata_copy(from: usize, length: usize, ret: &mut [u8]) -> Result<(),
 
 /// Returns the length of the data in the VM's return buffer.
 pub fn returndata_size() -> usize {
-    unsafe { native::ethereum_getReturnDataSize() as usize }
+    unsafe { native::getReturnDataSize() as usize }
 }
 
 /// Halts execution, reverts all changes to the state and consumes all gas.
@@ -612,28 +612,28 @@ pub fn abort() -> ! {
 /// Halts execution and reverts all changes to the state.
 pub fn revert() -> ! {
     unsafe {
-        native::ethereum_revert(0 as *const u32, 0 as u32);
+        native::revert(core::ptr::null::<u32>(), 0_u32);
     }
 }
 
 /// Fills the return buffer with the given data and halts execution, reverting all state changes.
 pub fn revert_data(data: &[u8]) -> ! {
     unsafe {
-        native::ethereum_revert(data.as_ptr() as *const u32, data.len() as u32);
+        native::revert(data.as_ptr() as *const u32, data.len() as u32);
     }
 }
 
 /// Ends execution, signalling success.
 pub fn finish() -> ! {
     unsafe {
-        native::ethereum_finish(0 as *const u32, 0 as u32);
+        native::finish(core::ptr::null::<u32>(), 0_u32);
     }
 }
 
 /// Fills the return buffer with the given data and halts execution, signalling success.
 pub fn finish_data(data: &[u8]) -> ! {
     unsafe {
-        native::ethereum_finish(data.as_ptr() as *const u32, data.len() as u32);
+        native::finish(data.as_ptr() as *const u32, data.len() as u32);
     }
 }
 
@@ -642,7 +642,7 @@ pub fn storage_load(key: &StorageKey) -> StorageValue {
     let mut ret = StorageValue::default();
 
     unsafe {
-        native::ethereum_storageLoad(
+        native::storageLoad(
             key.bytes.as_ptr() as *const u32,
             ret.bytes.as_mut_ptr() as *const u32,
         );
@@ -654,7 +654,7 @@ pub fn storage_load(key: &StorageKey) -> StorageValue {
 /// Sets the storage data at the specified key.
 pub fn storage_store(key: &StorageKey, value: &StorageValue) {
     unsafe {
-        native::ethereum_storageStore(
+        native::storageStore(
             key.bytes.as_ptr() as *const u32,
             value.bytes.as_ptr() as *const u32,
         );
@@ -664,6 +664,6 @@ pub fn storage_store(key: &StorageKey, value: &StorageValue) {
 /// Self-destructs the running contract, sending all its ether to a specified beneficiary address.
 pub fn selfdestruct(address: &Address) -> ! {
     unsafe {
-        native::ethereum_selfDestruct(address.bytes.as_ptr() as *const u32);
+        native::selfDestruct(address.bytes.as_ptr() as *const u32);
     }
 }

--- a/src/native.rs
+++ b/src/native.rs
@@ -1,20 +1,21 @@
 //! The low-level bindings for the Ethereum Environment Interface (EEI). There is a safe set of wrappers for these functions, so use
 //! those unless you are certain you know what you're doing.
 
+#[link(wasm_import_module = "ethereum")]
 extern "C" {
-    pub fn ethereum_useGas(amount: u64);
-    pub fn ethereum_getGasLeft() -> u64;
-    pub fn ethereum_getAddress(resultOffset: *const u32);
-    pub fn ethereum_getExternalBalance(addressOffset: *const u32, resultOffset: *const u32);
-    pub fn ethereum_getBlockCoinbase(resultOffset: *const u32);
-    pub fn ethereum_getBlockDifficulty(resultOffset: *const u32);
-    pub fn ethereum_getBlockGasLimit() -> u64;
-    pub fn ethereum_getBlockHash(number: u64, resultOffset: *const u32) -> u32;
-    pub fn ethereum_getBlockNumber() -> u64;
-    pub fn ethereum_getBlockTimestamp() -> u64;
-    pub fn ethereum_getTxGasPrice(valueOffset: *const u32);
-    pub fn ethereum_getTxOrigin(resultOffset: *const u32);
-    pub fn ethereum_log(
+    pub fn useGas(amount: u64);
+    pub fn getGasLeft() -> u64;
+    pub fn getAddress(resultOffset: *const u32);
+    pub fn getExternalBalance(addressOffset: *const u32, resultOffset: *const u32);
+    pub fn getBlockCoinbase(resultOffset: *const u32);
+    pub fn getBlockDifficulty(resultOffset: *const u32);
+    pub fn getBlockGasLimit() -> u64;
+    pub fn getBlockHash(number: u64, resultOffset: *const u32) -> u32;
+    pub fn getBlockNumber() -> u64;
+    pub fn getBlockTimestamp() -> u64;
+    pub fn getTxGasPrice(valueOffset: *const u32);
+    pub fn getTxOrigin(resultOffset: *const u32);
+    pub fn log(
         dataOffset: *const u32,
         length: u32,
         numberOfTopics: u32,
@@ -23,56 +24,56 @@ extern "C" {
         topic3: *const u32,
         topic4: *const u32,
     );
-    pub fn ethereum_call(
+    pub fn call(
         gas: u64,
         addressOffset: *const u32,
         valueOffset: *const u32,
         dataOffset: *const u32,
         dataLength: u32,
     ) -> u32;
-    pub fn ethereum_callCode(
+    pub fn callCode(
         gas: u64,
         addressOffset: *const u32,
         valueOffset: *const u32,
         dataOffset: *const u32,
         dataLength: u32,
     ) -> u32;
-    pub fn ethereum_callDelegate(
+    pub fn callDelegate(
         gas: u64,
         addressOffset: *const u32,
         dataOffset: *const u32,
         dataLength: u32,
     ) -> u32;
-    pub fn ethereum_callStatic(
+    pub fn callStatic(
         gas: u64,
         addressOffset: *const u32,
         dataOffset: *const u32,
         dataLength: u32,
     ) -> u32;
-    pub fn ethereum_create(
+    pub fn create(
         valueOffset: *const u32,
         dataOffset: *const u32,
         dataLength: u32,
         resultOffset: *const u32,
     ) -> u32;
-    pub fn ethereum_returnDataCopy(resultOffset: *const u32, dataOffset: u32, length: u32);
-    pub fn ethereum_getReturnDataSize() -> u32;
-    pub fn ethereum_finish(dataOffset: *const u32, length: u32) -> !;
-    pub fn ethereum_revert(dataOffset: *const u32, length: u32) -> !;
-    pub fn ethereum_callDataCopy(resultOffset: *const u32, dataOffset: u32, length: u32);
-    pub fn ethereum_getCallDataSize() -> u32;
-    pub fn ethereum_getCaller(resultOffset: *const u32);
-    pub fn ethereum_getCallValue(resultOffset: *const u32);
-    pub fn ethereum_codeCopy(resultOffset: *const u32, codeOffset: u32, length: u32);
-    pub fn ethereum_getCodeSize() -> u32;
-    pub fn ethereum_externalCodeCopy(
+    pub fn returnDataCopy(resultOffset: *const u32, dataOffset: u32, length: u32);
+    pub fn getReturnDataSize() -> u32;
+    pub fn finish(dataOffset: *const u32, length: u32) -> !;
+    pub fn revert(dataOffset: *const u32, length: u32) -> !;
+    pub fn callDataCopy(resultOffset: *const u32, dataOffset: u32, length: u32);
+    pub fn getCallDataSize() -> u32;
+    pub fn getCaller(resultOffset: *const u32);
+    pub fn getCallValue(resultOffset: *const u32);
+    pub fn codeCopy(resultOffset: *const u32, codeOffset: u32, length: u32);
+    pub fn getCodeSize() -> u32;
+    pub fn externalCodeCopy(
         addressOffset: *const u32,
         resultOffset: *const u32,
         codeOffset: u32,
         length: u32,
     );
-    pub fn ethereum_getExternalCodeSize(addressOfset: *const u32) -> u32;
-    pub fn ethereum_storageLoad(keyOffset: *const u32, resultOffset: *const u32);
-    pub fn ethereum_storageStore(keyOffset: *const u32, valueOffset: *const u32);
-    pub fn ethereum_selfDestruct(addressOffset: *const u32) -> !;
+    pub fn getExternalCodeSize(addressOfset: *const u32) -> u32;
+    pub fn storageLoad(keyOffset: *const u32, resultOffset: *const u32);
+    pub fn storageStore(keyOffset: *const u32, valueOffset: *const u32);
+    pub fn selfDestruct(addressOffset: *const u32) -> !;
 }


### PR DESCRIPTION
Use `wasm_import_module` and remove function name prefix